### PR TITLE
fix landscape layout on small screens 

### DIFF
--- a/android/app/src/main/res/layout-land/elevation_profile_bottom_sheet.xml
+++ b/android/app/src/main/res/layout-land/elevation_profile_bottom_sheet.xml
@@ -11,6 +11,7 @@
   android:clickable="true"
   android:focusable="true"
   android:fillViewport="true"
+  app:behavior_peekHeight="@dimen/elevation_profile_peek_height"
   app:layout_behavior="@string/placepage_behavior">
   <LinearLayout
     android:layout_width="match_parent"

--- a/android/app/src/main/res/layout-land/map_buttons_layout_regular.xml
+++ b/android/app/src/main/res/layout-land/map_buttons_layout_regular.xml
@@ -37,6 +37,7 @@
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:layout_alignParentEnd="true"
+    android:layout_above="@id/map_buttons_bottom"
     android:layout_below="@+id/map_buttons_top"
     android:clipChildren="false"
     android:clipToPadding="false"

--- a/android/app/src/main/res/values-land/dimens.xml
+++ b/android/app/src/main/res/values-land/dimens.xml
@@ -9,6 +9,11 @@
   <dimen name="nav_bottom_gap">24dp</dimen>
   <dimen name="zoom_buttons_margin">48dp</dimen>
 
+  <!-- 320x640 -->
+  <dimen name="elevation_profile_peek_height">72dp</dimen>
+  <dimen name="elevation_profile_chart_min_height">64dp</dimen>
+  <dimen name="elevation_profile_content_height">64dp</dimen>
+  
   <!-- Altitude chart -->
   <dimen name="altitude_chart_image_width">334dp</dimen>
 


### PR DESCRIPTION
This PR fix  landscape layout on small screens as discussed in https://github.com/swe-productivity/organicmaps/issues/2

Tested on android device where now search and zoom out buttons are visible without overlapping zoom out .
Elevation profile on small screens  is also visible.